### PR TITLE
update default erlang series version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 ---
-sudo: required
 language: python
+python:
+  - "2.7"
 cache: pip
 services:
   - docker
-matrix:
-  fast_finish: true
 
 stages:
   - name: tests
@@ -24,15 +23,18 @@ jobs:
       script: tox
       env:
         - ANSIBLE=2.5
-
     - <<: *test-tox
       env:
         - ANSIBLE=2.6
-
     - <<: *test-tox
       env:
         - ANSIBLE=2.7
-
+    - <<: *test-tox
+      env:
+        - ANSIBLE=2.8
+    - <<: *test-tox
+      env:
+        - ANSIBLE=2.9
     - stage: mkrelease
       install:
         - pip install git-semver ansible

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ ansible-role-erlang
 
 Ansible role to install Erlang/OTP versions provided by RabbitMQ.
 
+**/!\ Not compatible with ansible > 2.8.7 < 2.8.13 due to a [bug](https://github.com/ansible/ansible/issues/70081)**
+
 Requirements
 ------------
 
@@ -20,7 +22,7 @@ Role Variables
 Defaults variables are inside `defaults/main.yml`
 ```yaml
 ---
-erlang_series: 20
+erlang_series: 22
 
 erlang_rpm_repo_url: https://dl.bintray.com/rabbitmq-erlang/rpm/erlang
 erlang_rpm_gpg_url: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
@@ -38,7 +40,8 @@ erlang_series_deb_version:
 
 - `erlang_series`
 
-  - should be an integer (16,19,20,21 available at 01.16.2019)
+  - should be an integer (19,20,21,22,23 available at 06.14.2020)
+  - don't forget to choose a serie compatible with the rabbitmq version that will be installed (see [rabbitmq documentation](https://www.rabbitmq.com/which-erlang.html))
 
 - `erlang_rpm_repo_url`
 
@@ -102,7 +105,7 @@ Example Playbook
 ```yaml
 - hosts: rabbitmq
   roles:
-     - { role: rockandska.erlang, erlang_series: 19 }
+     - { role: rockandska.erlang, erlang_series: 20 }
 ```
 
 Local Testing

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-erlang_series: 20
+erlang_series: 22
 
 erlang_rpm_repo_url: https://dl.bintray.com/rabbitmq-erlang/rpm/erlang
 erlang_rpm_gpg_url: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc

--- a/molecule/test-requirements.txt
+++ b/molecule/test-requirements.txt
@@ -1,4 +1,4 @@
-molecule>=2.15.0
+molecule==2.20.0
 docker
 ansible-lint>=3.4.0
 testinfra>=1.7.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.8
-envlist = py{27}-ansible{25,26,27}
+envlist = py{27}-ansible{25,26,27,28,29}
 skipsdist = true
 
 [travis:env]
@@ -8,6 +8,8 @@ ANSIBLE=
   2.5: ansible25
   2.6: ansible26
   2.7: ansible27
+  2.8: ansible28
+  2.9: ansible29
 
 [testenv]
 passenv = *
@@ -16,5 +18,9 @@ deps =
     ansible25: ansible>=2.5, <2.6
     ansible26: ansible>=2.6, <2.7
     ansible27: ansible>=2.7, <2.8
+    # bug in ansible > 2.8.7 < 2.8.13
+    # see https://github.com/ansible/ansible/issues/70081
+    ansible28: ansible==2.8.7
+    ansible29: ansible>=2.9, <2.10
 commands =
     {posargs:molecule test --all --destroy=always}


### PR DESCRIPTION
- add tests for 2.8.x 2.9.x
- 2.8.x is fixed to 2.8.7 due to a [bug](https://github.com/ansible/ansible/issues/70081)