### PR TITLE
Move default repository from bintray to cloudsmith for RHEL releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: python
 python:
-  - "2.7"
+  - "3.6"
 cache: pip
 services:
   - docker

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ erlang_rpm_gpg_url: https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/gpg
 erlang_rpm_repo_tpl: etc/yum.repos.d/rabbitmq_erlang.repo.j2
 erlang_series_rpm_version:
 
-erlang_deb_repo_url: https://dl.bintray.com/rabbitmq-erlang/debian
-erlang_deb_gpg_url: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
+erlang_deb_repo_url: https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/deb
+erlang_deb_gpg_url: https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/gpg.E495BB49CC4BBE5B.key
 erlang_deb_repo_tpl: etc/apt/sources.list.d/rabbitmq_erlang.list.j2
 erlang_deb_pinning_tpl: etc/apt/preferences.d/erlang.j2
 erlang_series_deb_version:
@@ -41,7 +41,7 @@ erlang_series_deb_version:
 
 - `erlang_series`
 
-  - should be an integer (19,20,21,22,23 available at 06.14.2020)
+  - should be an integer (21,22,23 available at 06.19.2021)
   - don't forget to choose a serie compatible with the rabbitmq version that will be installed (see [rabbitmq documentation](https://www.rabbitmq.com/which-erlang.html))
 
 - `erlang_rpm_repo_url`
@@ -64,8 +64,8 @@ erlang_series_deb_version:
   - install a specific version of the `erlang_series` for the Centos / Redhat systems
   - examples:
     ```
-    20.3.8.15-1.el7.centos
-    20.3.8.17-1.el7.centos
+    20.3.8.15-1.el7
+    20.3.8.17-1.el7
     ```
 
 - `erlang_deb_repo_url`

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ Defaults variables are inside `defaults/main.yml`
 ---
 erlang_series: 22
 
+erlang_rpm_repo_url: https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/rpm/el
+erlang_rpm_gpg_url: https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/gpg.E495BB49CC4BBE5B.key
+erlang_rpm_repo_tpl: etc/yum.repos.d/rabbitmq_erlang.repo.j2
+erlang_series_rpm_version:
+
 erlang_deb_repo_url: https://dl.bintray.com/rabbitmq-erlang/debian
 erlang_deb_gpg_url: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
 erlang_deb_repo_tpl: etc/apt/sources.list.d/rabbitmq_erlang.list.j2

--- a/README.md
+++ b/README.md
@@ -20,14 +20,10 @@ Role Variables
 --------------
 
 Defaults variables are inside `defaults/main.yml`
+
 ```yaml
 ---
 erlang_series: 22
-
-erlang_rpm_repo_url: https://dl.bintray.com/rabbitmq-erlang/rpm/erlang
-erlang_rpm_gpg_url: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
-erlang_rpm_repo_tpl: etc/yum.repos.d/rabbitmq_erlang.repo.j2
-erlang_series_rpm_version:
 
 erlang_deb_repo_url: https://dl.bintray.com/rabbitmq-erlang/debian
 erlang_deb_gpg_url: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,8 +6,8 @@ erlang_rpm_gpg_url: https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/gpg
 erlang_rpm_repo_tpl: etc/yum.repos.d/rabbitmq_erlang.repo.j2
 erlang_series_rpm_version:
 
-erlang_deb_repo_url: https://dl.bintray.com/rabbitmq-erlang/debian
-erlang_deb_gpg_url: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
+erlang_deb_repo_url: https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/deb
+erlang_deb_gpg_url: https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/gpg.E495BB49CC4BBE5B.key
 erlang_deb_repo_tpl: etc/apt/sources.list.d/rabbitmq_erlang.list.j2
 erlang_deb_pinning_tpl: etc/apt/preferences.d/erlang.j2
 erlang_series_deb_version:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 erlang_series: 22
 
-erlang_rpm_repo_url: https://dl.bintray.com/rabbitmq-erlang/rpm/erlang
-erlang_rpm_gpg_url: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
+erlang_rpm_repo_url: https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/rpm/el
+erlang_rpm_gpg_url: https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/gpg.E495BB49CC4BBE5B.key
 erlang_rpm_repo_tpl: etc/yum.repos.d/rabbitmq_erlang.repo.j2
 erlang_series_rpm_version:
 

--- a/molecule/test-requirements.txt
+++ b/molecule/test-requirements.txt
@@ -1,6 +1,6 @@
 molecule==2.20.0
 docker
-ansible-lint>=3.4.0
+ansible-lint<=4.1
 testinfra>=1.7.0
 jmespath
 pytest==3.9.3

--- a/tasks/install_Debian.yml
+++ b/tasks/install_Debian.yml
@@ -31,5 +31,5 @@
 - name: "Install Erlang [Debian/Ubuntu]"
   apt:
     package:
-      - "erlang{{ erlang_series_deb_version | ternary ('=' + (erlang_series_deb_version | string),'') }}"
+      - erlang
     state: present

--- a/tasks/install_RedHat.yml
+++ b/tasks/install_RedHat.yml
@@ -13,7 +13,7 @@
 
 - name: Install Erlang [RHEL/CentOS]
   yum:
-    name: "erlang{{ erlang_series_rpm_version | ternary ('-' + (erlang_series_rpm_version | string),'') }}"
+    name: "erlang{{ erlang_series_rpm_version | ternary ('-' + (erlang_series_rpm_version | string),'-' + (erlang_series | string) + '*') }}"
     state: present
     disablerepo: "*"
     enablerepo: "rabbitmq_erlang"

--- a/tasks/install_RedHat.yml
+++ b/tasks/install_RedHat.yml
@@ -8,8 +8,8 @@
   register: yum_erlang_repository_file
 
 - name: Clean yum if template changed [RHEL/CentOS]
-  command: yum clean all
-  when: yum_erlang_repository_file.changed
+  command: yum clean all  # noqa 303
+  when: yum_erlang_repository_file.changed  # noqa 503
 
 - name: Install Erlang [RHEL/CentOS]
   yum:

--- a/tasks/install_RedHat.yml
+++ b/tasks/install_RedHat.yml
@@ -5,6 +5,11 @@
     dest: "/etc/yum.repos.d/{{ erlang_rpm_repo_tpl | basename | regex_replace('\\.j2$', '') }}"
     force: true
     backup: true
+  register: yum_erlang_repository_file
+
+- name: Clean yum if template changed [RHEL/CentOS]
+  command: yum clean all
+  when: yum_erlang_repository_file.changed
 
 - name: Install Erlang [RHEL/CentOS]
   yum:

--- a/templates/etc/apt/preferences.d/erlang.j2
+++ b/templates/etc/apt/preferences.d/erlang.j2
@@ -1,3 +1,3 @@
 Package: erlang*
-Pin: {{ erlang_series_deb_version | ternary('version ' + (erlang_series_deb_version | string),'release o=Bintray') }}
+Pin: version {{ erlang_series_deb_version | ternary( (erlang_series_deb_version| string), '1:' + (erlang_series | string) + '*') }}
 Pin-Priority: 1000

--- a/templates/etc/apt/sources.list.d/rabbitmq_erlang.list.j2
+++ b/templates/etc/apt/sources.list.d/rabbitmq_erlang.list.j2
@@ -1,1 +1,1 @@
-deb {{ erlang_deb_repo_url }} {{ ansible_distribution_release | lower }} erlang-{{ erlang_series }}.x
+deb {{ erlang_deb_repo_url }}/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }} main

--- a/templates/etc/yum.repos.d/rabbitmq_erlang.repo.j2
+++ b/templates/etc/yum.repos.d/rabbitmq_erlang.repo.j2
@@ -1,6 +1,6 @@
 [rabbitmq_erlang]
 name=rabbitmq_erlang
-baseurl={{ erlang_rpm_repo_url }}/{{ erlang_series }}/el/{{ ansible_distribution_major_version }}
+baseurl={{ erlang_rpm_repo_url }}/{{ ansible_distribution_major_version }}/$basearch
 repo_gpgcheck=0
 gpgcheck=1
 enabled=1

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.8
-envlist = py{27}-ansible{25,26,27,28,29}
+envlist = py{3}-ansible{25,26,27,28,29}
 skipsdist = true
 
 [travis:env]


### PR DESCRIPTION
As bintray went down 1.05.21 (https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/) a switch to cloudsmith repositories seems reasonable (https://www.rabbitmq.com/install-rpm.html#cloudsmith)